### PR TITLE
Intended https issue

### DIFF
--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -206,7 +206,9 @@ class UrlGenerator implements UrlGeneratorContract
         // generate a new one but will simply return the URL after changing the scheme,
         // which is convenient since we do not always have to check if it's valid.
         if ($this->isValidUrl($path)) {
-            return preg_replace('~^https?://~', $this->formatScheme($secure), $path);
+            return str_starts_with($path, $this->formatScheme($secure))
+                ? $path
+                : preg_replace('~^https?://~', $this->formatScheme($secure), $path);
         }
 
         $tail = implode('/', array_map(

--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -202,11 +202,11 @@ class UrlGenerator implements UrlGeneratorContract
      */
     public function to($path, $extra = [], $secure = null)
     {
-        // First we will check if the URL is already a valid URL. If it is we will not
-        // try to generate a new one but will simply return the URL as is, which is
-        // convenient since developers do not always have to check if it's valid.
+        // First we will check if the URL is already a valid URL. If it is we will not try to
+        // generate a new one but will simply return the URL after changing the scheme,
+        // which is convenient since we do not always have to check if it's valid.
         if ($this->isValidUrl($path)) {
-            return $path;
+            return preg_replace('~^https?://~', $this->formatScheme($secure), $path);
         }
 
         $tail = implode('/', array_map(

--- a/tests/Routing/RoutingUrlGeneratorTest.php
+++ b/tests/Routing/RoutingUrlGeneratorTest.php
@@ -694,13 +694,13 @@ class RoutingUrlGeneratorTest extends TestCase
             Request::create('http://www.foo.com/')
         );
 
-        $this->assertSame('http://www.bar.com/foo', $url->to('http://www.bar.com/foo'));
-        $this->assertSame('https://www.bar.com/foo', $url->to('http://www.bar.com/foo', [], true));
+        $this->assertSame('http://www.foo.com/bar', $url->to('http://www.foo.com/bar'));
+        $this->assertSame('https://www.foo.com/bar', $url->to('http://www.foo.com/bar', [], true));
 
         $url->forceScheme('https');
 
+        $this->assertSame('https://www.foo.com/bar', $url->to('http://www.foo.com/bar'));
         $this->assertSame('https://www.bar.com/foo', $url->to('http://www.bar.com/foo'));
-        $this->assertSame('https://www.random.com/foo', $url->to('http://www.random.com/foo'));
     }
 
     public function testPrevious()

--- a/tests/Routing/RoutingUrlGeneratorTest.php
+++ b/tests/Routing/RoutingUrlGeneratorTest.php
@@ -685,6 +685,22 @@ class RoutingUrlGeneratorTest extends TestCase
 
         $url->forceRootUrl('https://www.bar.com');
         $this->assertSame('https://www.bar.com/foo', $url->route('plain'));
+
+        /*
+         * Absolute URL with Force Scheme...
+         */
+        $url = new UrlGenerator(
+            $routes = new RouteCollection,
+            Request::create('http://www.foo.com/')
+        );
+
+        $this->assertSame('http://www.bar.com/foo', $url->to('http://www.bar.com/foo'));
+        $this->assertSame('https://www.bar.com/foo', $url->to('http://www.bar.com/foo', [], true));
+
+        $url->forceScheme('https');
+
+        $this->assertSame('https://www.bar.com/foo', $url->to('http://www.bar.com/foo'));
+        $this->assertSame('https://www.random.com/foo', $url->to('http://www.random.com/foo'));
     }
 
     public function testPrevious()


### PR DESCRIPTION
## TLDR;
Laravel's URL generator's `to` method doesn't modify valid URLs. It ignores `forceScheme` or parameters like `$secure=true`. 

This pull request fixes that. 

## Scenario:

Laravel app is deployed behind a load balancer, the load balancer is handling the HTTPS and the app is running on port 80. Also, in this scenario we can't allow TrustProxies  to $proxies = '*';

To solve the HTTPS URL site. We put something like this into the AppServiceProvoder.  

```php
if($this->app->environment('production')) {
    URL::forceScheme('https');
}

// Source: https://stackoverflow.com/a/51819095
```

Which is excellent and solves most issues around HTTPS URL generation. But it hits a minor issue related to `route()-> intended()` method. 

It puts the http version of the **full URL** into the session. And when it pulls the URL for redirection, it never transforms the URL into the forced scheme, as it doesn't regenerate the URL if the URL is valid.  

<details>
 <summary>🎥 Screencast of the error happening in real life</summary>

https://user-images.githubusercontent.com/13833460/218867367-f1f8649c-9797-4568-ae57-d86bdfb6a5ed.mp4
</details>


This also happens when using Cloudflare flexible SSL or tools like [gitpod](https://www.gitpod.io/). 

## Proposed Update

This PR adds a check to ensure that the valid absolute URL has the correct/forced scheme. If it doesn't, it updates the scheme. 



I understand TrustProxies is here to solve this type of issue. But I still thought this could be an improvement around the `forceScheme` option. 